### PR TITLE
Support for Play 2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
-name := "mobile-notifications-client"
+name := "mobile-notifications-client-play-2.4"
 
 organization := "com.gu"
 
@@ -15,7 +15,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.3.2",
+  "com.typesafe.play" %% "play-json" % "2.4.6",
   "net.databinder.dispatch" %% "dispatch-core" % "0.11.1" % Test,
   "org.specs2" %% "specs2" % "2.3.13" % "test",
   "com.github.tomakehurst" % "wiremock" % "1.33" % "test"

--- a/src/main/scala/com/gu/mobile.notifications.client/lib/JsonFormatsHelper.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/lib/JsonFormatsHelper.scala
@@ -10,9 +10,8 @@ import scala.util.Try
 
 object JsonFormatsHelper {
   implicit class RichJsObject(obj: JsObject) {
-    /* JsObject is actually ordered: this allows you to prepend key value pairs */
     def +:(kv: (String, JsValue)): JsObject = obj match {
-      case JsObject(entries) => JsObject(kv +: entries)
+      case JsObject(entries) => JsObject(entries + kv)
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.14-SNAPSHOT"
+version in ThisBuild := "0.5.13-SNAPSHOT"


### PR DESCRIPTION
- bump the version of play to 2.4
- change the artefact name to differentiate it from the mainstream one.
- decrement the minor version of the build so that next release aligns with the current one
- Fix the compilation error following the update of play 2.4