### PR TITLE
Make LegacyNotificationsBuilders result optional

### DIFF
--- a/src/main/scala/com/gu/mobile.notifications.client/legacy/AndroidPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/legacy/AndroidPayloadBuilder.scala
@@ -8,7 +8,7 @@ import com.gu.mobile.notifications.client.models.legacy.{AndroidKeys => keys}
 import scala.PartialFunction._
 
 object AndroidPayloadBuilder extends PlatformPayloadBuilder {
-  def build(np: NotificationPayload, editions: Set[Edition] = Set.empty): AndroidMessagePayload = np match {
+  def build(np: NotificationPayload, editions: Set[Edition] = Set.empty): Option[AndroidMessagePayload] = condOpt(np) {
     case ga: GoalAlertPayload => buildGoalAlert(ga)
     case ca: ContentAlertPayload => buildContentAlert(ca)
     case bn: BreakingNewsPayload => buildBreakingNews(bn, editions)

--- a/src/main/scala/com/gu/mobile.notifications.client/legacy/IosPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/legacy/IosPayloadBuilder.scala
@@ -6,10 +6,11 @@ import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.client.models.legacy.IOSMessagePayload
 import com.gu.mobile.notifications.client.models.legacy.{IosKeys => keys}
 import com.gu.mobile.notifications.client.models.legacy.IosMessageTypes._
+import PartialFunction.condOpt
 
 object IosPayloadBuilder extends PlatformPayloadBuilder {
 
-  def build(payload: NotificationPayload) = payload match {
+  def build(payload: NotificationPayload): Option[IOSMessagePayload] = condOpt(payload) {
     case ga: GoalAlertPayload => buildGoalAlert(ga)
     case bn: BreakingNewsPayload => buildBreakingNews(bn)
     case cn: ContentAlertPayload => buildContentAlert(cn)

--- a/src/main/scala/com/gu/mobile.notifications.client/legacy/NotificationBuilder.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/legacy/NotificationBuilder.scala
@@ -1,6 +1,5 @@
 package com.gu.mobile.notifications.client.legacy
 
-import java.util.UUID
 import java.util.concurrent.TimeUnit.MINUTES
 
 import com.gu.mobile.notifications.client.models.Editions.Edition
@@ -8,14 +7,15 @@ import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.client.models.legacy._
 
 import scala.concurrent.duration.Duration
+import PartialFunction.condOpt
 
 trait NotificationBuilder {
-  def buildNotification(notification: NotificationPayload): Notification
+  def buildNotification(notification: NotificationPayload): Option[Notification]
 }
 
 object NotificationBuilderImpl extends NotificationBuilder {
 
-  def buildNotification(notification: NotificationPayload) = notification match {
+  def buildNotification(notification: NotificationPayload): Option[Notification] = condOpt(notification) {
     case bnp: BreakingNewsPayload => buildBreakingNewsAlert(bnp)
     case cap: ContentAlertPayload => buildContentAlert(cap)
     case gap: GoalAlertPayload => buildGoalAlert(gap)
@@ -78,8 +78,8 @@ object NotificationBuilderImpl extends NotificationBuilder {
   }
 
   private def buildPlatFormPayloads(notification: NotificationPayload, editions: Set[Edition] = Set.empty) = MessagePayloads(
-    ios = Some(IosPayloadBuilder.build(notification)),
-    android = Some(AndroidPayloadBuilder.build(notification, editions))
+    ios = IosPayloadBuilder.build(notification),
+    android = AndroidPayloadBuilder.build(notification, editions)
   )
 
 }

--- a/src/test/scala/com/gu/mobile/notifications/client/LegacyApiClientSpec.scala
+++ b/src/test/scala/com/gu/mobile/notifications/client/LegacyApiClientSpec.scala
@@ -48,7 +48,7 @@ class LegacyApiClientSpec extends ApiClientSpec[LegacyApiClient] {
   val expectedPostUrl = s"$host/notifications?api-key=$apiKey"
 
   val fakeNotificationBuilder = mock[NotificationBuilder]
-  fakeNotificationBuilder.buildNotification(payload) returns notification
+  fakeNotificationBuilder.buildNotification(payload) returns Some(notification)
 
   override def getTestApiClient(httpProvider: HttpProvider) = new LegacyApiClient(
     apiKey = apiKey,

--- a/src/test/scala/com/gu/mobile/notifications/client/legacy/NotificationBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/notifications/client/legacy/NotificationBuilderSpec.scala
@@ -16,7 +16,7 @@ class NotificationBuilderSpec extends Specification with Mockito {
 
   "buildNotification" should {
     "return a well constructed Notification if a valid ContentAlertPayload is provided" in new ContentAlertScope {
-      buildNotification(cap) mustEqual expectedNotification
+      buildNotification(cap) mustEqual Some(expectedNotification)
     }
 
     "return a notification with an imageURI if it is on the ContentAlertPayload" in new ContentAlertScope {
@@ -25,31 +25,31 @@ class NotificationBuilderSpec extends Specification with Mockito {
 
       val notification = buildNotification(contentAlertPayload)
 
-      notification.payloads.android.get mustEqual expectedAndroidPayloadWithImage
+      notification.get.payloads.android.get mustEqual expectedAndroidPayloadWithImage
     }
 
     "compute an ID for an article" in new ContentAlertScope {
       val notification = buildNotification(cap)
-      notification.uniqueIdentifier mustEqual "contentNotifications/newArticle/capiId"
+      notification.get.uniqueIdentifier mustEqual "contentNotifications/newArticle/capiId"
     }
 
     "compute an ID for a liveblog block" in new ContentAlertScope {
       val content = cap.copy(link = link.copy(blockId = Some("block-abcdefgh")))
       val notification = buildNotification(content)
-      notification.uniqueIdentifier mustEqual "contentNotifications/newBlock/capiId/block-abcdefgh"
+      notification.get.uniqueIdentifier mustEqual "contentNotifications/newBlock/capiId/block-abcdefgh"
     }
 
     "return a well constructed Notification if a valid goal alert is provided" in new GoalAlertScope {
-      buildNotification(gap) mustEqual expectedNotification
+      buildNotification(gap) mustEqual Some(expectedNotification)
     }
 
     "return a well constructed Notification if a valid breaking news payload is provided" in new BreakingNewsScope {
-      buildNotification(bnp) mustEqual expectedNotification
+      buildNotification(bnp) mustEqual Some(expectedNotification)
     }
 
     "return the correct link format for each platform" in new PlatFormLinkTestScope {
 
-      val notification = buildNotification(bnpGuardianLink)
+      val notification = buildNotification(bnpGuardianLink).get
       notification.uniqueIdentifier mustEqual bnpGuardianLink.id
       notification.`type` mustEqual NotificationType.BreakingNews
       notification.payloads.isEmpty mustNotEqual true
@@ -71,7 +71,7 @@ class NotificationBuilderSpec extends Specification with Mockito {
         debug = true
       )
 
-      val notification = buildNotification(breakingNewsWithTopics)
+      val notification = buildNotification(breakingNewsWithTopics).get
       notification.target.topics mustEqual Set(BreakingNewsSport, NewsstandIos)
       notification.target.regions mustEqual Set(UK, US)
 


### PR DESCRIPTION
This is so that new notification types don’t need to be supported by legacy notifications