### PR TITLE
add a single client api object

### DIFF
--- a/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
@@ -78,5 +78,7 @@ object ApiClient {
     new CompositeApiClient(List(legacy, client))
   }
 
+  def apply(host: String, apiKey: String, httpProvider: HttpProvider) = new NextGenApiClient(host, apiKey, httpProvider)
+
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.33-SNAPSHOT"
+version in ThisBuild := "0.5.34"


### PR DESCRIPTION
This is part of the work to convert https://github.com/guardian/mobile-notifications-content into a Lambda. For this, we don't require the legacy notifications host, so I want to be able to construct an API client that doesn't post to it