### PR TITLE
add additional debug to message send

### DIFF
--- a/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
@@ -21,8 +21,11 @@ case class PartialApiError(errors: List[ErrorWithSource]) extends CompositeApiEr
 
 case class TotalApiError(errors: List[ErrorWithSource]) extends CompositeApiError
 
-case class ApiHttpError(status: Int) extends ApiClientError {
-  val description = s"Http error status $status"
+case class ApiHttpError(status: Int, body: Option[String] = None ) extends ApiClientError {
+  val description = body match {
+    case Some(b) => s"Http error: status: $status body: $b "
+    case _ => s"Http error: status: $status"
+  }
 }
 
 case class HttpProviderError(throwable: Throwable) extends ApiClientError {

--- a/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
+++ b/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
@@ -23,7 +23,7 @@ protected class NextGenApiClient(val host: String,
 
       val json = Json.stringify(Json.toJson(notificationPayload))
       postJson(url, json) map {
-        case error: HttpError => Left(ApiHttpError(error.status))
+        case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
         case HttpOk(201, body) => validateFormat[NextGenResponse](body)
         case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
       } recover {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.35-SNAPSHOT"
+version in ThisBuild := "0.5.35"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.35"
+version in ThisBuild := "0.5.35-SNAPSHOT"


### PR DESCRIPTION
This is to help with the replacement of the notifications-content service. At the moment when I message send fails, we can only log the status code. Replicating the post with curl yields more information (for instance duplicate content ) and this enables that info to be logged